### PR TITLE
File error

### DIFF
--- a/Baekjoon Online Judge/2579_계단 오르기.cpp
+++ b/Baekjoon Online Judge/2579_계단 오르기.cpp
@@ -1,0 +1,51 @@
+#include<iostream>
+#include<algorithm>
+#include<queue>
+#include<vector>
+#include<map>
+#include<stack>
+#include<string>
+#include<cstring>
+#include<sstream>
+#include<deque>
+using namespace std;
+
+#define MAX 301
+
+int n;
+int arr[MAX];
+int dp[MAX];
+
+int Max(int a, int b) {
+	if (a > b) return a;
+	return b;
+}
+
+
+int main()
+{
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+
+	cin >> n;
+	for (int i = 1; i <= n; i++)
+	{
+		cin >> arr[i];
+	}
+
+	dp[1] = arr[1]; //첫 번째 계단 까지의 최대값은 무조건 1 
+	dp[2] = arr[1] + arr[2]; // 두 번째 계단 최대값은 무조건 1+2
+	dp[3] = Max(arr[1] + arr[3], arr[2] + arr[3]);  //세 번째 최대값은 max(1+3 || 2+3)
+
+	// dp[n] = max( 이전 계단을 밟지 않고 온 경우 || 이전 계단을 밟고 온 경우 )
+	// dp[n] = max( dp[n-2] + array[n]|| dp[n-3] + array[n] + array[n-1] )
+
+	for (int i = 4; i <= n; i++)
+	{
+		dp[i] = Max(dp[i - 2] + arr[i], arr[i - 1] + dp[i - 3] + arr[i]);
+	}
+
+	cout << dp[n] << "\n";
+
+
+}

--- a/Baekjoon Online Judge/9095_1,2,3 더하기.cpp
+++ b/Baekjoon Online Judge/9095_1,2,3 더하기.cpp
@@ -1,0 +1,45 @@
+#include<iostream>
+#include<algorithm>
+#include<queue>
+#include<vector>
+#include<map>
+#include<stack>
+#include<string>
+#include<cstring>
+#include<sstream>
+#include<deque>
+using namespace std;
+#define MAX 11
+
+int testCase;
+int arr[MAX];
+
+int solve(int n)
+{
+	if (arr[n] != 0) return arr[n];
+
+	for (int i = 4; i <= n; i++)
+	{
+		arr[i] = arr[i - 1] + arr[i - 2] + arr[i - 3];
+	}
+	return arr[n];
+}
+
+int main()
+{
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+
+	arr[1] = 1;
+	arr[2] = 2;
+	arr[3] = 4;
+
+	cin >> testCase;
+	for (int i = 0; i < testCase; i++)
+	{
+		int num;
+		cin >> num;
+		cout << solve(num) << "\n";
+	}
+
+}


### PR DESCRIPTION
mac과 달리 window에서는 파일명의 특수문자를 저장하지 못해 
두 노트북간 작업 중 에러가 발생함.

당장 맥북이 없어서 파일명을 수정 후 푸시가 불가능해서
이를 해결하기 위해
1. 윈도우 노트북에서 새로운 브랜치 생성
2. 커밋 했음.

